### PR TITLE
Add document processing modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+*.parquet

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # ano-rag
+
+This repository provides tools for parsing documents and generating "atomic notes" for further stages in an RAG (Retrieval Augmented Generation) pipeline.
+
+## Features
+
+- Parsers for JSON, JSONL and Word (`.docx`) files.
+- Sentence-based chunking that avoids splitting in the middle of sentences.
+- Batch processing script that can process multiple files at once.
+- Uses GPU-accelerated cudf DataFrames when available, falling back to pandas otherwise.
+- Atomic notes are stored in Parquet format for downstream consumption.
+
+## Usage
+
+```
+./process_docs.py path/to/file1.json path/to/file2.docx -o output_dir
+```
+
+Use `--cpu` to disable cudf usage even if installed.

--- a/process_docs.py
+++ b/process_docs.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+import argparse
+
+from src.doc_processing.batch import process_files
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Process documents and generate atomic notes")
+    parser.add_argument('files', nargs='+', help='Files to process')
+    parser.add_argument('-o', '--output', default='output', help='Directory to write results')
+    parser.add_argument('--cpu', action='store_true', help='Force CPU (pandas) processing')
+    args = parser.parse_args()
+
+    out_path = process_files(args.files, args.output, use_gpu=not args.cpu)
+    print(f"Saved notes to {out_path}")
+
+
+if __name__ == '__main__':
+    main()

--- a/src/doc_processing/batch.py
+++ b/src/doc_processing/batch.py
@@ -1,0 +1,55 @@
+import importlib
+import json
+import os
+from typing import List, Callable, Dict
+
+import pandas as pd
+
+from .json_parser import parse_json
+from .jsonl_parser import parse_jsonl
+from .word_parser import parse_word
+from .notes import AtomicNote
+
+
+PARSERS: Dict[str, Callable[[str], List[AtomicNote]]] = {
+    '.json': parse_json,
+    '.jsonl': parse_jsonl,
+    '.jl': parse_jsonl,
+    '.docx': parse_word,
+}
+
+
+def get_dataframe_module(use_gpu: bool = True):
+    """Return cudf or pandas depending on availability and use_gpu flag."""
+    if use_gpu:
+        spec = importlib.util.find_spec('cudf')
+        if spec is not None:
+            cudf = importlib.import_module('cudf')
+            return cudf
+    return pd
+
+
+def parse_file(path: str) -> List[AtomicNote]:
+    ext = os.path.splitext(path)[1].lower()
+    parser = PARSERS.get(ext)
+    if not parser:
+        raise ValueError(f"Unsupported file type: {ext}")
+    return parser(path)
+
+
+def process_files(paths: List[str], output_dir: str, use_gpu: bool = True):
+    """Process multiple files and save atomic notes to output_dir."""
+    df_module = get_dataframe_module(use_gpu)
+    all_notes = []
+    for path in paths:
+        notes = parse_file(path)
+        for note in notes:
+            record = note.to_dict()
+            # Parquet does not support nested dicts by default
+            record['metadata'] = json.dumps(record['metadata'])
+            all_notes.append(record)
+    df = df_module.DataFrame(all_notes)
+    os.makedirs(output_dir, exist_ok=True)
+    out_path = os.path.join(output_dir, 'atomic_notes.parquet')
+    df.to_parquet(out_path)
+    return out_path

--- a/src/doc_processing/chunking.py
+++ b/src/doc_processing/chunking.py
@@ -1,0 +1,26 @@
+import re
+from typing import List
+
+
+SENTENCE_END_RE = re.compile(r'(?<=[.!?])\s+')
+
+
+def split_sentences(text: str) -> List[str]:
+    """Split text into sentences using simple regex."""
+    return [s.strip() for s in SENTENCE_END_RE.split(text) if s.strip()]
+
+
+def chunk_text(text: str, max_length: int = 200) -> List[str]:
+    """Chunk text into pieces, preserving sentence boundaries."""
+    sentences = split_sentences(text)
+    chunks = []
+    current = ''
+    for sentence in sentences:
+        if len(current) + len(sentence) + 1 > max_length and current:
+            chunks.append(current.strip())
+            current = sentence
+        else:
+            current = f"{current} {sentence}" if current else sentence
+    if current:
+        chunks.append(current.strip())
+    return chunks

--- a/src/doc_processing/json_parser.py
+++ b/src/doc_processing/json_parser.py
@@ -1,0 +1,28 @@
+import json
+from dataclasses import dataclass
+from typing import List, Dict
+
+from .notes import AtomicNote
+from .chunking import chunk_text
+
+
+def parse_json(path: str) -> List[AtomicNote]:
+    """Parse a JSON file and return a list of AtomicNote objects."""
+    with open(path, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+
+    notes = []
+    if isinstance(data, dict):
+        # Single document stored in a dict
+        text = data.get('text', '')
+        metadata = {k: v for k, v in data.items() if k != 'text'}
+        for chunk in chunk_text(text):
+            notes.append(AtomicNote(doc_id=path, content=chunk, metadata=metadata))
+    elif isinstance(data, list):
+        for idx, item in enumerate(data):
+            text = item.get('text', '') if isinstance(item, dict) else str(item)
+            metadata = item if isinstance(item, dict) else {'index': idx}
+            metadata = {k: v for k, v in metadata.items() if k != 'text'}
+            for chunk in chunk_text(text):
+                notes.append(AtomicNote(doc_id=f"{path}#{idx}", content=chunk, metadata=metadata))
+    return notes

--- a/src/doc_processing/jsonl_parser.py
+++ b/src/doc_processing/jsonl_parser.py
@@ -1,0 +1,25 @@
+import json
+from typing import List
+
+from .notes import AtomicNote
+from .chunking import chunk_text
+
+
+def parse_jsonl(path: str) -> List[AtomicNote]:
+    """Parse a JSONL file and return a list of AtomicNote objects."""
+    notes = []
+    with open(path, 'r', encoding='utf-8') as f:
+        for idx, line in enumerate(f):
+            if not line.strip():
+                continue
+            try:
+                data = json.loads(line)
+                text = data.get('text', '') if isinstance(data, dict) else str(data)
+                metadata = data if isinstance(data, dict) else {'index': idx}
+                metadata = {k: v for k, v in metadata.items() if k != 'text'}
+            except json.JSONDecodeError:
+                text = line.strip()
+                metadata = {'index': idx}
+            for chunk in chunk_text(text):
+                notes.append(AtomicNote(doc_id=f"{path}#{idx}", content=chunk, metadata=metadata))
+    return notes

--- a/src/doc_processing/notes.py
+++ b/src/doc_processing/notes.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass, asdict
+from typing import Dict
+
+
+@dataclass
+class AtomicNote:
+    doc_id: str
+    content: str
+    metadata: Dict
+
+    def to_dict(self) -> Dict:
+        d = asdict(self)
+        return d

--- a/src/doc_processing/word_parser.py
+++ b/src/doc_processing/word_parser.py
@@ -1,0 +1,13 @@
+from typing import List
+from docx import Document
+
+from .notes import AtomicNote
+from .chunking import chunk_text
+
+
+def parse_word(path: str) -> List[AtomicNote]:
+    """Parse a Word (.docx) file and return AtomicNote objects."""
+    doc = Document(path)
+    text = "\n".join(p.text for p in doc.paragraphs)
+    notes = [AtomicNote(doc_id=path, content=chunk, metadata={}) for chunk in chunk_text(text)]
+    return notes


### PR DESCRIPTION
## Summary
- implement sentence-based chunking
- add parsers for JSON, JSONL, and Word files
- add batch processing with cudf/pandas and CLI
- generate atomic notes
- update README

## Testing
- `python -m py_compile process_docs.py src/doc_processing/*.py`
- `./process_docs.py samples/sample.json -o samples/output`

------
https://chatgpt.com/codex/tasks/task_e_6864ac0956d0832da65e7e73fb55b27f