### PR TITLE
Add embedding utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
 # ano-rag
+
+This repository contains utilities for working with retrieval augmented generation (RAG).
+
+## Embedding Utilities
+
+The `src/embeddings` package provides an `EmbeddingModel` class capable of loading
+`bge-m3` or `nomic-embed` models from HuggingFace, a local path or an Ollama
+instance. Batch embedding is supported and can optionally return `cudf` data
+frames when GPU acceleration via RAPIDS is available.  Example usage:
+
+```python
+from embeddings.model import EmbeddingModel
+from embeddings.vector_store import VectorStore
+
+model = EmbeddingModel("bge-m3", provider="huggingface")
+embs = model.embed_batch(["hello", "world"], batch_size=2)
+store = VectorStore(dim=len(embs[0]))
+store.add(embs, ["hello", "world"])
+store.save()
+```
+
+The `VectorStore` class wraps a simple FAISS index which can be persisted to
+local files.

--- a/src/embeddings/__init__.py
+++ b/src/embeddings/__init__.py
@@ -1,0 +1,4 @@
+from .model import EmbeddingModel
+from .vector_store import VectorStore
+
+__all__ = ["EmbeddingModel", "VectorStore"]

--- a/src/embeddings/model.py
+++ b/src/embeddings/model.py
@@ -1,0 +1,59 @@
+import json
+from typing import Iterable, List, Optional
+
+import numpy as np
+
+try:
+    import cudf
+except ImportError:  # cudf is optional
+    cudf = None
+
+try:
+    from sentence_transformers import SentenceTransformer
+except ImportError:
+    SentenceTransformer = None
+
+import requests
+
+
+class EmbeddingModel:
+    """Utility class for embedding text using bge-m3 or nomic-embed models."""
+
+    def __init__(self, model: str, provider: str = "huggingface", device: str = "cpu", use_cudf: bool = False):
+        self.model_name = model
+        self.provider = provider
+        self.device = device
+        self.use_cudf = use_cudf and cudf is not None
+        self.model = None
+        self._load_model()
+
+    def _load_model(self):
+        if self.provider in {"huggingface", "local"}:
+            if SentenceTransformer is None:
+                raise ImportError("sentence-transformers is required for HuggingFace models")
+            self.model = SentenceTransformer(self.model_name, device=self.device)
+        elif self.provider == "ollama":
+            # Ollama requires a running instance accessible via HTTP
+            self.model = None  # nothing to load
+        else:
+            raise ValueError(f"Unsupported provider: {self.provider}")
+
+    def embed_batch(self, texts: Iterable[str], batch_size: int = 32) -> List[np.ndarray]:
+        texts = list(texts)
+        if self.provider == "ollama":
+            return [self._embed_ollama(text) for text in texts]
+        if self.model is None:
+            raise RuntimeError("Model not loaded")
+        embeddings = self.model.encode(texts, batch_size=batch_size, convert_to_numpy=True)
+        if self.use_cudf:
+            return cudf.DataFrame(embeddings)
+        return [emb for emb in embeddings]
+
+    def _embed_ollama(self, text: str) -> np.ndarray:
+        url = "http://localhost:11434/api/embeddings"
+        payload = {"model": self.model_name, "prompt": text}
+        response = requests.post(url, json=payload, timeout=60)
+        response.raise_for_status()
+        data = response.json()
+        return np.array(data.get("embedding", []), dtype=np.float32)
+

--- a/src/embeddings/vector_store.py
+++ b/src/embeddings/vector_store.py
@@ -1,0 +1,51 @@
+import os
+import pickle
+from typing import List, Sequence
+
+import numpy as np
+
+try:
+    import faiss
+except ImportError:
+    faiss = None
+
+
+class VectorStore:
+    """Simple FAISS-based vector store with optional persistence."""
+
+    def __init__(self, dim: int, persist_path: str = "store.faiss"):
+        if faiss is None:
+            raise ImportError("faiss is required for VectorStore")
+        self.dim = dim
+        self.persist_path = persist_path
+        self.index = faiss.IndexFlatL2(dim)
+        self.texts: List[str] = []
+
+    def add(self, embeddings: Sequence[np.ndarray], texts: Sequence[str]):
+        vecs = np.vstack(embeddings).astype("float32")
+        self.index.add(vecs)
+        self.texts.extend(texts)
+
+    def search(self, query: np.ndarray, top_k: int = 5):
+        query = query.reshape(1, -1).astype("float32")
+        distances, idx = self.index.search(query, top_k)
+        results = []
+        for i, dist in zip(idx[0], distances[0]):
+            if i == -1:
+                continue
+            results.append((self.texts[i], float(dist)))
+        return results
+
+    def save(self):
+        faiss.write_index(self.index, self.persist_path)
+        meta_path = os.path.splitext(self.persist_path)[0] + ".pkl"
+        with open(meta_path, "wb") as f:
+            pickle.dump(self.texts, f)
+
+    def load(self):
+        if os.path.exists(self.persist_path):
+            self.index = faiss.read_index(self.persist_path)
+            meta_path = os.path.splitext(self.persist_path)[0] + ".pkl"
+            if os.path.exists(meta_path):
+                with open(meta_path, "rb") as f:
+                    self.texts = pickle.load(f)


### PR DESCRIPTION
## Summary
- implement `EmbeddingModel` to load bge-m3 and nomic-embed from HuggingFace, a local path, or Ollama
- support batch embedding with optional cudf output
- add `VectorStore` class backed by FAISS
- document embedding utilities in README

## Testing
- `python -m py_compile src/embeddings/__init__.py src/embeddings/model.py src/embeddings/vector_store.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864ad8ff9ec832d94fef515d73238f4