### PR TITLE
Add configurable data and work directories

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -89,6 +89,9 @@ storage:
   graph_db_path: "./data/graph_store"
   processed_docs_path: "./data/processed"
   cache_path: "./data/cache"
+  source_docs_dir: "./data"
+  result_root: "./result"
+  work_dir: null
   
 # Evaluation
 eval:


### PR DESCRIPTION
## Summary
- make source and work dirs configurable in `config.yaml`
- default to latest folder under `result` unless `--new` is used
- store caches under the work directory
- allow query to pick work directory from config

## Testing
- `pytest -q`
- `python -m py_compile main.py doc/document_processor.py`
- `python main.py process --new` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6865570adff0832dbf3da2806ba1b243