### PR TITLE
Fix write_json argument order

### DIFF
--- a/vector_store/retriever.py
+++ b/vector_store/retriever.py
@@ -404,7 +404,7 @@ class VectorRetriever:
             
             # 保存原子笔记
             notes_file = os.path.join(self.data_dir, 'atomic_notes.json')
-            FileUtils.write_json(notes_file, self.atomic_notes)
+            FileUtils.write_json(self.atomic_notes, notes_file)
             
             # 保存嵌入
             if self.note_embeddings is not None:
@@ -413,10 +413,10 @@ class VectorRetriever:
             
             # 保存ID映射
             mapping_file = os.path.join(self.data_dir, 'id_mappings.json')
-            FileUtils.write_json(mapping_file, {
+            FileUtils.write_json({
                 'note_id_to_index': self.note_id_to_index,
                 'index_to_note_id': self.index_to_note_id
-            })
+            }, mapping_file)
             
             logger.info("Index data saved successfully")
             

--- a/vector_store/vector_index.py
+++ b/vector_store/vector_index.py
@@ -285,7 +285,7 @@ class VectorIndex:
             }
             
             metadata_file = filepath.replace('.faiss', '_metadata.json')
-            FileUtils.write_json(metadata_file, metadata)
+            FileUtils.write_json(metadata, metadata_file)
             
             logger.info(f"Index saved to {filepath}")
             return filepath


### PR DESCRIPTION
## Summary
- fix `FileUtils.write_json` argument order when saving metadata
- fix `FileUtils.write_json` usage in retriever

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68655a0d62f4832db67bd9b87bc3a580