### PR TITLE
Add loading of prebuilt indexes

### DIFF
--- a/graph/graph_index.py
+++ b/graph/graph_index.py
@@ -1,9 +1,12 @@
 import networkx as nx
 from typing import Dict, Any
 from loguru import logger
+from networkx.readwrite import json_graph
+from utils import FileUtils
 
 class GraphIndex:
     """Index wrapper for the knowledge graph."""
+
     def __init__(self, graph: nx.Graph = None):
         self.graph = graph or nx.Graph()
         self.node_centrality: Dict[str, float] = {}
@@ -19,3 +22,13 @@ class GraphIndex:
 
     def get_centrality(self, node_id: str) -> float:
         return self.node_centrality.get(node_id, 0.0)
+
+    def load_index(self, filepath: str):
+        """Load graph data from a JSON file and build the index."""
+        try:
+            data = FileUtils.read_json(filepath)
+            graph = json_graph.node_link_graph(data)
+            self.build_index(graph)
+            logger.info(f"Graph loaded from {filepath}")
+        except Exception as e:
+            logger.error(f"Failed to load graph index: {e}")

--- a/main.py
+++ b/main.py
@@ -58,7 +58,16 @@ def query_mode(args):
         logger.error(f'Notes file not found: {notes_file}')
         return
     notes = FileUtils.read_json(notes_file)
-    processor = QueryProcessor(notes)
+
+    graph_file = os.path.join(work_dir, 'graph.json')
+    faiss_files = glob(os.path.join(work_dir, '*.faiss'))
+    vector_index_file = faiss_files[0] if faiss_files else None
+
+    processor = QueryProcessor(
+        notes,
+        graph_file=graph_file if os.path.exists(graph_file) else None,
+        vector_index_file=vector_index_file if vector_index_file and os.path.exists(vector_index_file) else None,
+    )
     output = processor.process(args.query)
     print(output['answer'])
 


### PR DESCRIPTION
## Summary
- enable graph index loading from graph.json
- optionally load vector index and graph in QueryProcessor
- pass stored index paths in `query_mode`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68655c8fe86c832d9fa0153771f754db