### PR TITLE
Improve GPU install docs and add cupy conflict check

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,17 @@ pip install -r requirements.txt
 conda install -c rapidsai -c conda-forge cudf cuml cugraph
 ```
 
+如果安装后 `import cudf` 仍然失败，可能是由于系统中存在多个 `cupy` 版本导致冲突，可按
+以下步骤清理并重新安装 RAPIDS：
+
+```bash
+# 删除所有已安装的 cupy 包
+conda remove -y cupy cupy-cuda*
+
+# 重新安装 RAPIDS
+conda install -c rapidsai -c conda-forge cudf cuml cugraph
+```
+
 3. **配置Ollama**
 ```bash
 # 安装Ollama

--- a/utils/gpu_utils.py
+++ b/utils/gpu_utils.py
@@ -11,6 +11,17 @@ try:
 except ImportError:
     CUDF_AVAILABLE = False
     logger.warning("CUDF not available, falling back to CPU processing")
+    try:
+        import pkg_resources
+        cupy_pkgs = [d.project_name for d in pkg_resources.working_set
+                     if d.project_name.lower().startswith("cupy")]
+        if len(cupy_pkgs) > 1:
+            logger.warning(
+                f"Multiple cupy packages detected: {cupy_pkgs}. "
+                "Remove conflicts and reinstall RAPIDS."
+            )
+    except Exception as e:
+        logger.debug(f"Failed to check cupy packages: {e}")
 
 class GPUUtils:
     """GPU工具类，用于管理CUDA和cuDF的使用"""


### PR DESCRIPTION
## Summary
- clarify GPU installation troubleshooting in README
- warn about multiple `cupy` packages when RAPIDS import fails

## Testing
- `python -m py_compile utils/gpu_utils.py`
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_68657871b20c832dbac5efa63e1eedb3