### PR TITLE
Use weighted PageRank for graph centrality

### DIFF
--- a/graph/graph_index.py
+++ b/graph/graph_index.py
@@ -17,7 +17,13 @@ class GraphIndex:
         if self.graph.number_of_nodes() == 0:
             logger.warning("Empty graph for indexing")
             return
-        self.node_centrality = nx.degree_centrality(self.graph)
+        # Use edge weights when calculating node importance. Fall back to
+        # PageRank which supports weighted edges.
+        try:
+            self.node_centrality = nx.pagerank(self.graph, weight="weight")
+        except Exception as e:
+            logger.error(f"Failed weighted centrality computation: {e}")
+            self.node_centrality = nx.pagerank(self.graph)
         logger.info("Graph index built")
 
     def get_centrality(self, node_id: str) -> float:


### PR DESCRIPTION
## Summary
- calculate node importance with weighted PageRank in `GraphIndex.build_index`

## Testing
- `python -m py_compile graph/graph_index.py`
- `python verify_setup.py` *(fails: missing data directories)*
- `python test_batch.py` *(fails: ModuleNotFoundError: No module named 'jsonlines')*

------
https://chatgpt.com/codex/tasks/task_e_686dfae7cb70832d86c5032eea343d4a