### PR TITLE
Add topic group relation extraction

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -66,6 +66,10 @@ multi_hop:
     enabled: true
     batch_size: 16
     max_pairs_per_batch: 50
+  topic_group_llm:
+    enabled: true
+    min_group_size: 3
+    max_notes: 5
   
 # Query Processing
 query:

--- a/tests/test_query_processor.py
+++ b/tests/test_query_processor.py
@@ -4,6 +4,19 @@ import os, sys, types
 import numpy as np
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 sys.modules['ollama'] = types.SimpleNamespace(Client=lambda *a, **k: None)
+sys.modules['torch'] = types.SimpleNamespace(cuda=types.SimpleNamespace(is_available=lambda: False))
+sys.modules['tqdm'] = types.SimpleNamespace(tqdm=lambda x, **k: x)
+sys.modules['jsonlines'] = types.SimpleNamespace()
+sys.modules['docx'] = types.SimpleNamespace(Document=lambda *a, **k: None)
+sys.modules['yaml'] = types.SimpleNamespace(safe_load=lambda *a, **k: {})
+sys.modules['transformers'] = types.SimpleNamespace(
+    AutoTokenizer=object,
+    AutoModelForCausalLM=object,
+    pipeline=lambda *a, **k: None
+)
+sys.modules['requests'] = types.SimpleNamespace()
+sys.modules['sentence_transformers'] = types.SimpleNamespace(SentenceTransformer=lambda *a, **k: None)
+sys.modules['faiss'] = types.SimpleNamespace()
 
 from query.query_processor import QueryProcessor
 from config import config
@@ -15,6 +28,7 @@ class QueryProcessorTestCase(unittest.TestCase):
             {"note_id": "n2", "content": "two"}
         ]
 
+    @patch('graph.graph_index.GraphIndex.build_index')
     @patch('llm.OllamaClient.generate_final_answer', return_value='answer')
     @patch('llm.OllamaClient.evaluate_answer', return_value={'relevance':1})
     @patch('vector_store.embedding_manager.EmbeddingManager._load_local_model')
@@ -22,7 +36,7 @@ class QueryProcessorTestCase(unittest.TestCase):
     @patch('vector_store.VectorRetriever.search')
     @patch('graph.enhanced_graph_retriever.EnhancedGraphRetriever.retrieve_with_reasoning_paths')
     @patch('utils.context_scheduler.MultiHopContextScheduler.schedule_for_multi_hop')
-    def test_multi_hop_enabled(self, mock_sched, mock_retrieve, mock_search, m_enc, m_load, m_eval, m_gen):
+    def test_multi_hop_enabled(self, mock_sched, mock_retrieve, mock_search, m_enc, m_load, m_eval, m_gen, mock_index):
         mock_search.return_value = [[{"note_id":"n1","content":"one","retrieval_info":{"similarity":1}}]]
         mock_retrieve.return_value = [{"note_id":"n2","content":"two","reasoning_paths":[{"path":["n1","n2"],"path_score":0.9}]}]
         mock_sched.side_effect = lambda notes, paths: notes
@@ -36,6 +50,7 @@ class QueryProcessorTestCase(unittest.TestCase):
         self.assertTrue(res['reasoning'])
         self.assertIn('reasoning_paths', res['notes'][1])
 
+    @patch('graph.graph_index.GraphIndex.build_index')
     @patch('llm.OllamaClient.generate_final_answer', return_value='answer')
     @patch('llm.OllamaClient.evaluate_answer', return_value={'relevance':1})
     @patch('vector_store.embedding_manager.EmbeddingManager._load_local_model')
@@ -43,7 +58,7 @@ class QueryProcessorTestCase(unittest.TestCase):
     @patch('vector_store.VectorRetriever.search')
     @patch('graph.graph_retriever.GraphRetriever.retrieve')
     @patch('utils.context_scheduler.ContextScheduler.schedule')
-    def test_single_hop(self, mock_sched, mock_retrieve, mock_search, m_enc, m_load, m_eval, m_gen):
+    def test_single_hop(self, mock_sched, mock_retrieve, mock_search, m_enc, m_load, m_eval, m_gen, mock_index):
         mock_search.return_value = [[{"note_id":"n1","content":"one","retrieval_info":{"similarity":1}}]]
         mock_retrieve.return_value = [{"note_id":"n2","content":"two"}]
         mock_sched.side_effect = lambda notes: notes

--- a/tests/test_topic_group_relations.py
+++ b/tests/test_topic_group_relations.py
@@ -1,0 +1,46 @@
+import unittest
+from unittest.mock import patch
+import os, sys, types
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+sys.modules['ollama'] = types.SimpleNamespace(Client=lambda *a, **k: None)
+sys.modules['torch'] = types.SimpleNamespace(cuda=types.SimpleNamespace(is_available=lambda: False))
+sys.modules['tqdm'] = types.SimpleNamespace(tqdm=lambda x, **k: x)
+sys.modules['jsonlines'] = types.SimpleNamespace()
+sys.modules['docx'] = types.SimpleNamespace(Document=lambda *a, **k: None)
+sys.modules['yaml'] = types.SimpleNamespace(safe_load=lambda *a, **k: {})
+sys.modules['transformers'] = types.SimpleNamespace(
+    AutoTokenizer=object,
+    AutoModelForCausalLM=object,
+    pipeline=lambda *a, **k: None
+)
+sys.modules['requests'] = types.SimpleNamespace()
+sys.modules['sentence_transformers'] = types.SimpleNamespace(SentenceTransformer=lambda *a, **k: None)
+sys.modules['faiss'] = types.SimpleNamespace()
+
+from graph.enhanced_relation_extractor import EnhancedRelationExtractor
+from config import config
+
+class TopicGroupRelationsTestCase(unittest.TestCase):
+    def setUp(self):
+        self.notes = [
+            {"note_id": "n1", "content": "A1", "cluster_id": 1, "topic": "t"},
+            {"note_id": "n2", "content": "A2", "cluster_id": 1, "topic": "t"},
+            {"note_id": "n3", "content": "A3", "cluster_id": 1, "topic": "t"},
+        ]
+
+    @patch('llm.LocalLLM.generate', return_value='[{"source_index":0,"target_index":1,"relation_type":"causal","strength":0.8,"confidence":0.9}]')
+    def test_group_relations_generated(self, mock_gen):
+        config.update_config({'multi_hop': {
+            'topic_group_llm': {'enabled': True, 'min_group_size': 3, 'max_notes': 5},
+            'llm_relation_extraction': {'enabled': False}
+        }})
+
+        extractor = EnhancedRelationExtractor()
+        rels = extractor.extract_all_relations(self.notes)
+        found = any(r['relation_type'] == 'causal' and r['source_id'] == 'n1' and r['target_id'] == 'n2' for r in rels)
+        self.assertTrue(found)
+        mock_gen.assert_called()
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- enhance EnhancedRelationExtractor with `_extract_topic_group_relations`
- enable new config section for topic group LLM
- invoke topic group relation extraction when extracting all relations
- add unit tests with mocks to validate topic group behaviour

## Testing
- `pytest tests/test_topic_group_relations.py tests/test_query_processor.py -q`
- `pytest -q` *(fails: Expected None, but test returned True)*

------
https://chatgpt.com/codex/tasks/task_e_6870185d180c832db5efd4c9908ee9d2