### PR TITLE
Introduce shared JSON utilities

### DIFF
--- a/llm/local_llm.py
+++ b/llm/local_llm.py
@@ -3,7 +3,7 @@ from transformers import AutoTokenizer, AutoModelForCausalLM, pipeline
 from typing import List, Dict, Any, Optional
 from loguru import logger
 from config import config
-from utils import BatchProcessor
+from utils import BatchProcessor, extract_json_from_response
 from .ollama_client import OllamaClient
 from .prompts import (
     ATOMIC_NOTE_SYSTEM_PROMPT,
@@ -143,8 +143,7 @@ class LocalLLM:
             
             try:
                 import json
-                # 清理响应，移除可能的markdown代码块标记
-                cleaned_response = self._clean_json_response(response)
+                cleaned_response = extract_json_from_response(response)
                 note_data = json.loads(cleaned_response)
                 return {
                     'original_text': chunk,
@@ -181,9 +180,8 @@ class LocalLLM:
         
         try:
             import json
-            # 清理响应，移除可能的markdown代码块标记
-            cleaned_response = self._clean_json_response(response)
-            return json.loads(cleaned_response)
+            cleaned_response = extract_json_from_response(response)
+            return json.loads(cleaned_response) if cleaned_response else {'entities': [], 'relations': []}
         except json.JSONDecodeError:
             return {'entities': [], 'relations': []}
     
@@ -204,54 +202,6 @@ class LocalLLM:
         except Exception:
             return False
     
-    def _clean_json_response(self, response: str) -> str:
-        """清理LLM响应，移除markdown代码块标记和其他格式"""
-        if not response:
-            return "{}"
-        
-        # 清理控制字符
-        response = self._clean_control_characters(response)
-        
-        # 移除markdown代码块标记
-        response = response.strip()
-        if response.startswith('```json'):
-            response = response[7:]
-        elif response.startswith('```'):
-            response = response[3:]
-        
-        if response.endswith('```'):
-            response = response[:-3]
-        
-        # 移除可能的前后空白和换行
-        response = response.strip()
-        
-        # 尝试提取JSON对象
-        import re
-        # 查找第一个完整的JSON对象
-        json_match = re.search(r'\{[^{}]*(?:\{[^{}]*\}[^{}]*)*\}', response)
-        if json_match:
-            response = json_match.group(0)
-        
-        # 如果响应为空或不是JSON格式，返回空对象
-        if not response or not (response.startswith('{') or response.startswith('[')):
-            return "{}"
-        
-        return response
-    
-    def _clean_control_characters(self, text: str) -> str:
-        """清理字符串中的无效控制字符"""
-        import re
-        
-        # 移除或替换无效的控制字符，但保留有效的空白字符（空格、制表符、换行符）
-        # 保留 \t (\x09), \n (\x0A), \r (\x0D) 和普通空格 (\x20)
-        cleaned = re.sub(r'[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]', '', text)
-        
-        # 替换一些常见的问题字符
-        cleaned = cleaned.replace('\u0000', '')  # NULL字符
-        cleaned = cleaned.replace('\u0001', '')  # SOH字符
-        cleaned = cleaned.replace('\u0002', '')  # STX字符
-        
-        return cleaned
     
     def cleanup(self):
         """清理模型资源"""

--- a/llm/query_rewriter.py
+++ b/llm/query_rewriter.py
@@ -2,6 +2,7 @@ import json
 from typing import List, Dict, Any, Optional
 from loguru import logger
 from .local_llm import LocalLLM
+from utils import extract_json_from_response
 from config import config
 from .prompts import (
     QUERY_ANALYSIS_SYSTEM_PROMPT,
@@ -68,8 +69,7 @@ class QueryRewriter:
         
         try:
             response = self.llm.generate(prompt, system_prompt)
-            # 清理响应，移除可能的markdown代码块标记
-            cleaned_response = self._clean_json_response(response)
+            cleaned_response = extract_json_from_response(response)
             analysis = json.loads(cleaned_response)
             
             # 验证和补充默认值
@@ -102,7 +102,7 @@ class QueryRewriter:
         
         try:
             response = self.llm.generate(prompt, system_prompt)
-            cleaned_response = self._clean_json_response(response)
+            cleaned_response = extract_json_from_response(response)
             result = json.loads(cleaned_response)
             sub_queries = result.get('sub_queries', [query])
             
@@ -145,7 +145,7 @@ class QueryRewriter:
         
         try:
             response = self.llm.generate(prompt, system_prompt)
-            cleaned_response = self._clean_json_response(response)
+            cleaned_response = extract_json_from_response(response)
             result = json.loads(cleaned_response)
             optimized_queries = result.get('optimized_queries', [query])
             
@@ -173,7 +173,7 @@ class QueryRewriter:
             
             try:
                 response = self.llm.generate(prompt, system_prompt)
-                cleaned_response = self._clean_json_response(response)
+                cleaned_response = extract_json_from_response(response)
                 result = json.loads(cleaned_response)
                 
                 confidence = result.get('confidence', 0.0)
@@ -231,51 +231,3 @@ class QueryRewriter:
         
         return rewrite_result
     
-    def _clean_json_response(self, response: str) -> str:
-        """清理LLM响应，移除markdown代码块标记和其他格式"""
-        if not response:
-            return "{}"
-        
-        # 清理控制字符
-        response = self._clean_control_characters(response)
-        
-        # 移除markdown代码块标记
-        response = response.strip()
-        if response.startswith('```json'):
-            response = response[7:]
-        elif response.startswith('```'):
-            response = response[3:]
-        
-        if response.endswith('```'):
-            response = response[:-3]
-        
-        # 移除可能的前后空白和换行
-        response = response.strip()
-        
-        # 尝试提取JSON对象
-        import re
-        # 查找第一个完整的JSON对象
-        json_match = re.search(r'\{[^{}]*(?:\{[^{}]*\}[^{}]*)*\}', response)
-        if json_match:
-            response = json_match.group(0)
-        
-        # 如果响应为空或不是JSON格式，返回空对象
-        if not response or not (response.startswith('{') or response.startswith('[')):
-            return "{}"
-        
-        return response
-    
-    def _clean_control_characters(self, text: str) -> str:
-        """清理字符串中的无效控制字符"""
-        import re
-        
-        # 移除或替换无效的控制字符，但保留有效的空白字符（空格、制表符、换行符）
-        # 保留 \t (\x09), \n (\x0A), \r (\x0D) 和普通空格 (\x20)
-        cleaned = re.sub(r'[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]', '', text)
-        
-        # 替换一些常见的问题字符
-        cleaned = cleaned.replace('\u0000', '')  # NULL字符
-        cleaned = cleaned.replace('\u0001', '')  # SOH字符
-        cleaned = cleaned.replace('\u0002', '')  # STX字符
-        
-        return cleaned

--- a/tests/test_json_utils.py
+++ b/tests/test_json_utils.py
@@ -1,0 +1,37 @@
+import unittest
+import sys, types, os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.modules['jsonlines'] = types.SimpleNamespace()
+sys.modules['docx'] = types.SimpleNamespace(Document=lambda *a, **k: None)
+sys.modules['yaml'] = types.SimpleNamespace(safe_load=lambda *a, **k: {})
+sys.modules['loguru'] = types.SimpleNamespace(
+    logger=types.SimpleNamespace(
+        info=lambda *a, **k: None,
+        debug=lambda *a, **k: None,
+        warning=lambda *a, **k: None,
+        error=lambda *a, **k: None,
+    )
+)
+sys.modules['torch'] = types.SimpleNamespace(cuda=types.SimpleNamespace(is_available=lambda: False))
+sys.modules['cudf'] = types.SimpleNamespace()
+sys.modules['tqdm'] = types.SimpleNamespace(tqdm=lambda x, **k: x)
+from utils.json_utils import clean_control_characters, extract_json_from_response
+
+class JsonUtilsTestCase(unittest.TestCase):
+    def test_clean_control_characters(self):
+        text = "a\x00b\x01c\n"
+        self.assertEqual(clean_control_characters(text), "abc\n")
+
+    def test_extract_from_codeblock(self):
+        resp = "```json\n{\"a\":1}\n```"
+        self.assertEqual(extract_json_from_response(resp), '{"a":1}')
+
+    def test_extract_from_surrounding_text(self):
+        resp = "prefix {\"b\":2} suffix"
+        self.assertEqual(extract_json_from_response(resp), '{"b":2}')
+
+    def test_extract_invalid(self):
+        self.assertEqual(extract_json_from_response("nothing here"), "")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_query_processor.py
+++ b/tests/test_query_processor.py
@@ -4,6 +4,7 @@ import os, sys, types
 import numpy as np
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 sys.modules['ollama'] = types.SimpleNamespace(Client=lambda *a, **k: None)
+sys.modules['loguru'] = types.SimpleNamespace(logger=types.SimpleNamespace(info=lambda *a, **k: None, debug=lambda *a, **k: None, warning=lambda *a, **k: None, error=lambda *a, **k: None))
 sys.modules['torch'] = types.SimpleNamespace(cuda=types.SimpleNamespace(is_available=lambda: False))
 sys.modules['tqdm'] = types.SimpleNamespace(tqdm=lambda x, **k: x)
 sys.modules['jsonlines'] = types.SimpleNamespace()

--- a/tests/test_topic_group_relations.py
+++ b/tests/test_topic_group_relations.py
@@ -4,6 +4,7 @@ import os, sys, types
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 sys.modules['ollama'] = types.SimpleNamespace(Client=lambda *a, **k: None)
+sys.modules['loguru'] = types.SimpleNamespace(logger=types.SimpleNamespace(info=lambda *a, **k: None, debug=lambda *a, **k: None, warning=lambda *a, **k: None, error=lambda *a, **k: None))
 sys.modules['torch'] = types.SimpleNamespace(cuda=types.SimpleNamespace(is_available=lambda: False))
 sys.modules['tqdm'] = types.SimpleNamespace(tqdm=lambda x, **k: x)
 sys.modules['jsonlines'] = types.SimpleNamespace()

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -4,6 +4,15 @@ from .gpu_utils import GPUUtils
 from .batch_processor import BatchProcessor
 from .context_scheduler import ContextScheduler
 from .logging_utils import setup_logging
+from .json_utils import clean_control_characters, extract_json_from_response
 
-__all__ = ['FileUtils', 'TextUtils', 'GPUUtils', 'BatchProcessor', 'ContextScheduler',
-           'setup_logging']
+__all__ = [
+    'FileUtils',
+    'TextUtils',
+    'GPUUtils',
+    'BatchProcessor',
+    'ContextScheduler',
+    'setup_logging',
+    'clean_control_characters',
+    'extract_json_from_response',
+]

--- a/utils/json_utils.py
+++ b/utils/json_utils.py
@@ -1,0 +1,57 @@
+import json
+import re
+
+
+def clean_control_characters(text: str) -> str:
+    """Remove most control characters but keep common whitespace."""
+    if not isinstance(text, str):
+        return text
+    cleaned = re.sub(r'[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]', '', text)
+    cleaned = cleaned.replace('\u0000', '').replace('\u0001', '').replace('\u0002', '')
+    return cleaned
+
+
+def extract_json_from_response(response: str) -> str:
+    """Try to extract a JSON string from a larger LLM response."""
+    if not response or not str(response).strip():
+        return ""
+
+    text = clean_control_characters(str(response).strip())
+
+    # If the whole text is JSON
+    try:
+        json.loads(text)
+        return text
+    except Exception:
+        pass
+
+    # Remove common markdown code block markers
+    if text.startswith('```') and text.endswith('```'):
+        text_block = re.sub(r'^```(?:json)?', '', text[:-3], flags=re.IGNORECASE).strip()
+        try:
+            json.loads(text_block)
+            return text_block
+        except Exception:
+            pass
+
+    # Search for JSON inside markdown code block
+    code_match = re.search(r'```(?:json)?\s*(\{.*?\}|\[.*?\])\s*```', text, re.DOTALL | re.IGNORECASE)
+    if code_match:
+        candidate = clean_control_characters(code_match.group(1).strip())
+        try:
+            json.loads(candidate)
+            return candidate
+        except Exception:
+            pass
+
+    # Search for JSON object or array in the text
+    brace_match = re.search(r'(\{.*\}|\[.*\])', text, re.DOTALL)
+    if brace_match:
+        candidate = clean_control_characters(brace_match.group(1))
+        try:
+            json.loads(candidate)
+            return candidate
+        except Exception:
+            pass
+
+    return ""


### PR DESCRIPTION
## Summary
- add `json_utils` with helpers for cleaning control characters and extracting JSON
- use these helpers across LLM modules and relation extractor
- expose helpers through `utils.__init__`
- add unit tests for the new utilities
- update existing tests to stub dependencies

## Testing
- `python -m pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_68701b5468c0832d98825db8880f807e