### PR TITLE
Extend graph index persistence

### DIFF
--- a/graph/graph_index.py
+++ b/graph/graph_index.py
@@ -1,5 +1,7 @@
+import os
+import numpy as np
 import networkx as nx
-from typing import Dict, Any
+from typing import Dict, Any, List, Optional
 from loguru import logger
 from networkx.readwrite import json_graph
 from utils import FileUtils
@@ -9,11 +11,32 @@ class GraphIndex:
 
     def __init__(self, graph: nx.Graph = None):
         self.graph = graph or nx.Graph()
+        self.embeddings: Optional[np.ndarray] = None
+        self.note_id_to_index: Dict[str, int] = {}
+        self.index_to_note_id: Dict[int, str] = {}
         self.node_centrality: Dict[str, float] = {}
 
-    def build_index(self, graph: nx.Graph):
+    def build_index(
+        self,
+        graph: nx.Graph,
+        atomic_notes: Optional[List[Dict[str, Any]]] = None,
+        embeddings: Optional[np.ndarray] = None,
+    ) -> None:
         """Prepare internal structures for fast retrieval."""
         self.graph = graph
+
+        if atomic_notes is not None:
+            self.note_id_to_index = {}
+            self.index_to_note_id = {}
+            for idx, note in enumerate(atomic_notes):
+                note_id = note.get("note_id")
+                if note_id is not None:
+                    self.note_id_to_index[note_id] = idx
+                    self.index_to_note_id[idx] = note_id
+
+        if embeddings is not None:
+            self.embeddings = embeddings
+
         if self.graph.number_of_nodes() == 0:
             logger.warning("Empty graph for indexing")
             return
@@ -26,8 +49,21 @@ class GraphIndex:
             self.node_centrality = nx.pagerank(self.graph)
         logger.info("Graph index built")
 
+    @property
+    def centrality_scores(self) -> Dict[str, float]:
+        return self.node_centrality
+
     def get_centrality(self, node_id: str) -> float:
         return self.node_centrality.get(node_id, 0.0)
+
+    def get_embedding(self, note_id: str) -> Optional[np.ndarray]:
+        """Return embedding vector for a note if available."""
+        if self.embeddings is None:
+            return None
+        idx = self.note_id_to_index.get(note_id)
+        if idx is None or idx >= len(self.embeddings):
+            return None
+        return self.embeddings[idx]
 
     def load_index(self, filepath: str):
         """Load graph data from a JSON file and build the index."""
@@ -35,6 +71,42 @@ class GraphIndex:
             data = FileUtils.read_json(filepath)
             graph = json_graph.node_link_graph(data, edges="links")
             self.build_index(graph)
+
+            base = os.path.splitext(filepath)[0]
+            embed_file = base + "_embeddings.npz"
+            mapping_file = base + "_mappings.json"
+
+            if os.path.exists(embed_file):
+                loaded = np.load(embed_file)
+                self.embeddings = loaded["embeddings"]
+
+            if os.path.exists(mapping_file):
+                mapping = FileUtils.read_json(mapping_file)
+                self.note_id_to_index = mapping.get("note_id_to_index", {})
+                self.index_to_note_id = mapping.get("index_to_note_id", {})
+
             logger.info(f"Graph loaded from {filepath}")
         except Exception as e:
             logger.error(f"Failed to load graph index: {e}")
+
+    def save_index(self, filepath: str) -> None:
+        """Persist the graph and associated arrays."""
+        try:
+            data = json_graph.node_link_data(self.graph)
+            FileUtils.write_json(data, filepath)
+
+            base = os.path.splitext(filepath)[0]
+            embed_file = base + "_embeddings.npz"
+            mapping_file = base + "_mappings.json"
+
+            if self.embeddings is not None:
+                np.savez_compressed(embed_file, embeddings=self.embeddings)
+
+            FileUtils.write_json({
+                "note_id_to_index": self.note_id_to_index,
+                "index_to_note_id": self.index_to_note_id,
+            }, mapping_file)
+
+            logger.info(f"Graph saved to {filepath}")
+        except Exception as e:
+            logger.error(f"Failed to save graph index: {e}")

--- a/graph/multi_hop_query_processor.py
+++ b/graph/multi_hop_query_processor.py
@@ -35,11 +35,11 @@ class MultiHopQueryProcessor:
             except Exception as exc:  # pragma: no cover - corrupted file
                 logger.error(f"Failed to load graph index: {exc}, rebuilding")
                 graph = builder.build_graph(atomic_notes, embeddings)
-                self.graph_index.build_index(graph)
+                self.graph_index.build_index(graph, atomic_notes, embeddings)
         else:
             graph = builder.build_graph(atomic_notes, embeddings)
             self.graph_index = GraphIndex(graph)
-            self.graph_index.build_index(graph)
+            self.graph_index.build_index(graph, atomic_notes, embeddings)
 
         self.retriever = EnhancedGraphRetriever(self.graph_index)
 

--- a/query/query_processor.py
+++ b/query/query_processor.py
@@ -60,11 +60,11 @@ class QueryProcessor:
             except Exception as e:
                 logger.error(f"Failed to load graph index: {e}, rebuilding")
                 graph = builder.build_graph(atomic_notes, embeddings)
-                self.graph_index.build_index(graph)
+                self.graph_index.build_index(graph, atomic_notes, embeddings)
         else:
             graph = builder.build_graph(atomic_notes, embeddings)
             self.graph_index = GraphIndex()
-            self.graph_index.build_index(graph)
+            self.graph_index.build_index(graph, atomic_notes, embeddings)
 
         self.multi_hop_enabled = config.get('multi_hop.enabled', False) and ENHANCED_COMPONENTS_AVAILABLE
         if self.multi_hop_enabled:


### PR DESCRIPTION
## Summary
- add embeddings and id mappings to `GraphIndex`
- persist these arrays when saving/loading graph index
- pass note data and embeddings to GraphIndex during construction

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870bfd44544832db835f5a3880c7446