### PR TITLE
Enable graph indexing with saved embeddings

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ import argparse
 import os
 from datetime import datetime
 from glob import glob
+import numpy as np
 from doc import DocumentProcessor
 from config import config
 from query import QueryProcessor
@@ -91,9 +92,17 @@ def query_mode(args):
     graph_file = os.path.join(work_dir, 'graph.json')
     faiss_files = glob(os.path.join(work_dir, '*.faiss'))
     vector_index_file = faiss_files[0] if faiss_files else None
+    embed_file = os.path.join(work_dir, 'embeddings.npy')
+    embeddings = None
+    if os.path.exists(embed_file):
+        try:
+            embeddings = np.load(embed_file)
+        except Exception as e:
+            logger.warning(f'Failed to load embeddings: {e}')
 
     processor = QueryProcessor(
         notes,
+        embeddings,
         graph_file=graph_file if os.path.exists(graph_file) else None,
         vector_index_file=vector_index_file if vector_index_file and os.path.exists(vector_index_file) else None,
     )

--- a/query/query_processor.py
+++ b/query/query_processor.py
@@ -43,12 +43,22 @@ class QueryProcessor:
                 self.vector_retriever.vector_index.load_index(os.path.basename(vector_index_file))
                 self.vector_retriever.atomic_notes = atomic_notes
                 self.vector_retriever._build_id_mappings()
+                # load stored embeddings if available
+                embed_file = os.path.join(dir_path, "note_embeddings.npz")
+                if os.path.exists(embed_file):
+                    try:
+                        loaded = np.load(embed_file)
+                        self.vector_retriever.note_embeddings = loaded["embeddings"]
+                    except Exception as e:
+                        logger.warning(f"Failed to load stored embeddings: {e}")
                 logger.info(f"Loaded vector index from {vector_index_file}")
             except Exception as e:
                 logger.error(f"Failed to load vector index: {e}, rebuilding")
                 self.vector_retriever.build_index(atomic_notes)
         else:
             self.vector_retriever.build_index(atomic_notes)
+        if embeddings is None:
+            embeddings = self.vector_retriever.note_embeddings
 
         builder = GraphBuilder()
         graph = None


### PR DESCRIPTION
## Summary
- load stored embeddings when initializing `QueryProcessor`
- forward embeddings to graph builder/index and multi-hop processor
- load embeddings in CLI query mode for faster startup

## Testing
- `pip install numpy networkx loguru --quiet`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870c1166e48832d9711b81f0885f2af