### PR TITLE
Incorporate importance_score into graph ranking

### DIFF
--- a/graph/enhanced_graph_retriever.py
+++ b/graph/enhanced_graph_retriever.py
@@ -325,8 +325,10 @@ class EnhancedGraphRetriever:
                 # 节点中心性
                 centrality = self.graph_index.centrality_scores.get(node_id, 0.0)
                 
+                # 节点重要性
+                importance = self.graph.nodes[node_id].get("importance_score", 1.0)
                 # 节点得分
-                node_score = 0.7 * similarity + 0.3 * centrality
+                node_score = (0.7 * similarity + 0.3 * centrality) * importance
                 node_scores.append(node_score)
             else:
                 node_scores.append(0.1)

--- a/graph/graph_retriever.py
+++ b/graph/graph_retriever.py
@@ -34,7 +34,8 @@ class GraphRetriever:
                 data["graph_distance"] = dist
                 centrality = self.index.get_centrality(node_id)
                 data["centrality"] = centrality
-                data["graph_score"] = centrality / (dist + 1e-5)
+                importance = data.get("importance_score", 1.0)
+                data["graph_score"] = (centrality / (dist + 1e-5)) * importance
                 results.append(data)
         results.sort(key=lambda x: x.get("graph_score", 0), reverse=True)
         logger.info(f"Graph retrieval returned {len(results)} notes")


### PR DESCRIPTION
## Summary
- weight `GraphRetriever` scores by node importance
- factor node `importance_score` when computing enhanced retriever node scores
- prefer higher `importance_score` nodes in query processor tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68764e87b368832da0a318276e696023