### PR TITLE
Add fast semantic relation extraction option

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -67,9 +67,11 @@ multi_hop:
       confidence_threshold: 0.8
   llm_relation_extraction:
     enabled: true
+    use_fast_model: false
     batch_size: 32
     max_pairs_per_batch: 100
     candidate_selection_threshold: 0.2
+    fast_model_name: sentence-transformers/distiluse-base-multilingual-cased
   topic_group_llm:
     enabled: true
     min_group_size: 3

--- a/graph/enhanced_relation_extractor.py
+++ b/graph/enhanced_relation_extractor.py
@@ -7,6 +7,7 @@ from loguru import logger
 from utils import TextUtils, GPUUtils, BatchProcessor, extract_json_from_response
 from config import config
 from llm import LocalLLM
+from sentence_transformers import SentenceTransformer
 
 class EnhancedRelationExtractor:
     """增强的关系提取器，专门针对多跳推理优化"""
@@ -22,9 +23,12 @@ class EnhancedRelationExtractor:
         self.multi_hop_config = config.get('multi_hop', {})
         self.max_reasoning_hops = self.multi_hop_config.get('max_reasoning_hops', 3)
         self.min_path_confidence = self.multi_hop_config.get('min_path_confidence', 0.6)
-        
+
         # LLM关系提取配置
-        self.llm_extraction_enabled = self.multi_hop_config.get('llm_relation_extraction', {}).get('enabled', True)
+        llm_rel_cfg = self.multi_hop_config.get('llm_relation_extraction', {})
+        self.llm_relation_config = llm_rel_cfg
+        self.llm_extraction_enabled = llm_rel_cfg.get('enabled', True)
+        self.use_fast_model = llm_rel_cfg.get('use_fast_model', False)
 
         # 主题组LLM配置
         self.topic_group_config = self.multi_hop_config.get('topic_group_llm', {})
@@ -32,7 +36,7 @@ class EnhancedRelationExtractor:
 
         # 如果任一LLM相关功能启用，则初始化LLM
         self.llm = None
-        if self.llm_extraction_enabled or self.topic_group_enabled:
+        if ((self.llm_extraction_enabled and not self.use_fast_model) or self.topic_group_enabled):
             self.llm = LocalLLM()
         
         # 批处理器
@@ -80,11 +84,17 @@ class EnhancedRelationExtractor:
         # 在主题关系之后，根据主题组进一步挖掘关系
         group_relations = self._extract_topic_group_relations(atomic_notes)
         all_relations.extend(group_relations)
-        
-        # 2. 智能语义关系提取（使用LLM）
-        if self.llm_extraction_enabled and self.llm:
-            logger.info("Extracting semantic relations with LLM")
-            semantic_relations = self._extract_semantic_relations_with_llm(atomic_notes)
+
+        # 2. 智能语义关系提取
+        if self.llm_extraction_enabled:
+            if self.use_fast_model:
+                logger.info("Extracting semantic relations with fast model")
+                semantic_relations = self._extract_semantic_relations_fast(atomic_notes)
+            elif self.llm:
+                logger.info("Extracting semantic relations with LLM")
+                semantic_relations = self._extract_semantic_relations_with_llm(atomic_notes)
+            else:
+                semantic_relations = []
             all_relations.extend(semantic_relations)
         
         # 3. 推理路径关系提取
@@ -222,6 +232,55 @@ class EnhancedRelationExtractor:
         except Exception as e:
             logger.warning(f"Failed to parse topic group relations: {e}")
             return []
+
+    def _extract_semantic_relations_fast(self, atomic_notes: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """使用本地小模型快速提取语义关系"""
+        if not atomic_notes:
+            return []
+
+        # 延迟加载模型
+        if not hasattr(self, "_fast_model"):
+            model_name = self.llm_relation_config.get(
+                "fast_model_name", "sentence-transformers/distiluse-base-multilingual-cased"
+            )
+            self._fast_model = SentenceTransformer(model_name)
+
+        contents = [note.get("content", "") for note in atomic_notes]
+        note_ids = [note.get("note_id") for note in atomic_notes]
+        embeddings = self._fast_model.encode(contents, convert_to_numpy=True)
+        id_to_emb = {nid: emb for nid, emb in zip(note_ids, embeddings)}
+
+        candidate_pairs = self._select_candidate_pairs_for_llm_analysis(atomic_notes)
+
+        relations = []
+        for note1, note2 in candidate_pairs:
+            emb1 = id_to_emb.get(note1.get("note_id"))
+            emb2 = id_to_emb.get(note2.get("note_id"))
+            if emb1 is None or emb2 is None:
+                continue
+
+            sim = float(np.dot(emb1, emb2) / (np.linalg.norm(emb1) * np.linalg.norm(emb2) + 1e-8))
+
+            # 简单的基于相似度的启发式分类
+            if sim > 0.75:
+                relation_type = "support"
+            elif sim > 0.6:
+                relation_type = "comparison"
+            else:
+                continue
+
+            relations.append({
+                "source_id": note1.get("note_id"),
+                "target_id": note2.get("note_id"),
+                "relation_type": relation_type,
+                "weight": sim,
+                "metadata": {
+                    "similarity": sim,
+                    "extraction_method": "fast_semantic"
+                }
+            })
+
+        return relations
     
     def _extract_semantic_relations_with_llm(self, atomic_notes: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """使用LLM提取语义关系"""

--- a/tests/test_fast_semantic_relations.py
+++ b/tests/test_fast_semantic_relations.py
@@ -1,0 +1,129 @@
+import os
+import sys
+import importlib.util
+import pytest
+
+import types
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, ROOT_DIR)
+
+from config import config
+
+utils_stub = types.ModuleType('utils')
+
+class _Dummy:
+    pass
+
+class _Batch:
+    def __init__(self, *args, **kwargs):
+        pass
+
+utils_stub.TextUtils = _Dummy
+utils_stub.GPUUtils = _Dummy
+utils_stub.BatchProcessor = _Batch
+utils_stub.extract_json_from_response = lambda x: x
+sys.modules['utils'] = utils_stub
+
+llm_stub = types.ModuleType('llm')
+class _LLM:
+    def generate(self, prompt):
+        return ""
+llm_stub.LocalLLM = _LLM
+sys.modules['llm'] = llm_stub
+
+MODULE_PATH = os.path.join(ROOT_DIR, 'graph', 'enhanced_relation_extractor.py')
+spec = importlib.util.spec_from_file_location('enhanced_relation_extractor', MODULE_PATH)
+ere_module = importlib.util.module_from_spec(spec)
+sys.modules['enhanced_relation_extractor'] = ere_module
+spec.loader.exec_module(ere_module)
+EnhancedRelationExtractor = ere_module.EnhancedRelationExtractor
+
+class DummyModel:
+    def encode(self, sentences, convert_to_numpy=True):
+        # return identical embeddings to yield high similarity
+        return [[1.0, 0.0] for _ in sentences]
+
+class DummyLLM:
+    def generate(self, prompt):
+        return ""
+
+
+def test_fast_model_produces_relations(monkeypatch):
+    cfg = config.load_config()
+    cfg['multi_hop']['llm_relation_extraction']['use_fast_model'] = True
+    cfg['multi_hop']['llm_relation_extraction']['enabled'] = True
+
+    monkeypatch.setattr(
+        'enhanced_relation_extractor.SentenceTransformer',
+        lambda *args, **kwargs: DummyModel()
+    )
+    monkeypatch.setattr(
+        'enhanced_relation_extractor.LocalLLM',
+        lambda *args, **kwargs: DummyLLM()
+    )
+
+    extractor = EnhancedRelationExtractor()
+    notes = [
+        {
+            'note_id': '1',
+            'content': 'Cats are small animals.',
+            'keywords': ['cats', 'animals'],
+            'entities': ['cat'],
+            'topic': 'cats'
+        },
+        {
+            'note_id': '2',
+            'content': 'Cats are small animals that purr.',
+            'keywords': ['cats', 'animals'],
+            'entities': ['cat'],
+            'topic': 'cats'
+        },
+    ]
+
+    relations = extractor._extract_semantic_relations_fast(notes)
+    assert relations
+    r = relations[0]
+    assert r['source_id'] == '1'
+    assert r['target_id'] == '2'
+    assert r['relation_type'] in ('support', 'comparison')
+
+
+def test_config_toggle_switches_methods(monkeypatch):
+    cfg = config.load_config()
+    cfg['multi_hop']['llm_relation_extraction']['enabled'] = True
+
+    calls = {'fast': 0, 'llm': 0}
+
+    def fake_fast(self, notes):
+        calls['fast'] += 1
+        return []
+
+    def fake_llm(self, notes):
+        calls['llm'] += 1
+        return []
+
+    monkeypatch.setattr(EnhancedRelationExtractor, '_extract_semantic_relations_fast', fake_fast)
+    monkeypatch.setattr(EnhancedRelationExtractor, '_extract_semantic_relations_with_llm', fake_llm)
+    monkeypatch.setattr(
+        'enhanced_relation_extractor.LocalLLM',
+        lambda *args, **kwargs: DummyLLM()
+    )
+
+    cfg['multi_hop']['llm_relation_extraction']['use_fast_model'] = True
+    extractor = EnhancedRelationExtractor()
+    extractor.extract_all_relations([
+        {'note_id': '1', 'content': 'a', 'keywords': ['a'], 'entities': []},
+        {'note_id': '2', 'content': 'b', 'keywords': ['b'], 'entities': []},
+    ])
+    assert calls['fast'] == 1
+    assert calls['llm'] == 0
+
+    cfg['multi_hop']['llm_relation_extraction']['use_fast_model'] = False
+    extractor2 = EnhancedRelationExtractor()
+    extractor2.extract_all_relations([
+        {'note_id': '1', 'content': 'a', 'keywords': ['a'], 'entities': []},
+        {'note_id': '2', 'content': 'b', 'keywords': ['b'], 'entities': []},
+    ])
+    assert calls['fast'] == 1
+    assert calls['llm'] == 1


### PR DESCRIPTION
## Summary
- add fast semantic relation extraction using sentence-transformers with heuristic classification
- toggle LLM or fast path via `use_fast_model` config flag
- test new fast relation extraction and configuration toggle

## Testing
- `pytest tests/test_fast_semantic_relations.py::test_fast_model_produces_relations -q`
- `pytest tests/test_fast_semantic_relations.py::test_config_toggle_switches_methods -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895b10c2e1c832dbfbaab1fa89eb05b