### PR TITLE
Share LocalLLM instance across processors

### DIFF
--- a/doc/document_processor.py
+++ b/doc/document_processor.py
@@ -17,8 +17,8 @@ from graph import GraphBuilder
 
 class DocumentProcessor:
     """文档处理器主类，整合所有文档处理功能"""
-    
-    def __init__(self, output_dir: Optional[str] = None):
+
+    def __init__(self, output_dir: Optional[str] = None, llm: Optional[LocalLLM] = None):
         # 初始化组件
         self.chunker = DocumentChunker()
         self.clustering = TopicClustering()
@@ -31,7 +31,7 @@ class DocumentProcessor:
             if work_dir:
                 cache_dir = os.path.join(work_dir, 'cache')
         self.incremental_processor = IncrementalProcessor(cache_dir=cache_dir)
-        self.llm = LocalLLM()
+        self.llm = llm or LocalLLM()
         self.atomic_note_generator = AtomicNoteGenerator(self.llm)
         self.batch_processor = BatchProcessor(
             batch_size=config.get('document.batch_size', 32),

--- a/eval/evaluator.py
+++ b/eval/evaluator.py
@@ -1,12 +1,13 @@
-from typing import List, Dict
+from typing import List, Dict, Optional
 from loguru import logger
 from config import config
 from query import QueryProcessor
+from llm import LocalLLM
 
 class Evaluator:
     """Simple evaluation module processing queries in batch."""
-    def __init__(self, atomic_notes: List[Dict], embeddings=None):
-        self.processor = QueryProcessor(atomic_notes, embeddings)
+    def __init__(self, atomic_notes: List[Dict], embeddings=None, llm: Optional[LocalLLM] = None):
+        self.processor = QueryProcessor(atomic_notes, embeddings, llm=llm)
         self.batch_size = config.get('eval.batch_size', 16)
 
     def run(self, queries: List[str]) -> List[Dict[str, any]]:

--- a/graph/enhanced_relation_extractor.py
+++ b/graph/enhanced_relation_extractor.py
@@ -4,10 +4,7 @@ import numpy as np
 from typing import List, Dict, Any, Set, Tuple, Optional
 from collections import defaultdict, Counter
 from loguru import logger
-from utils.text_utils import TextUtils
-from utils.gpu_utils import GPUUtils
-from utils.batch_processor import BatchProcessor
-from utils.json_utils import extract_json_from_response
+from utils import TextUtils, GPUUtils, BatchProcessor, extract_json_from_response
 from config import config
 from llm import LocalLLM
 from sentence_transformers import SentenceTransformer

--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ from config import config
 from query import QueryProcessor
 from utils import FileUtils, setup_logging
 from loguru import logger
+from llm import LocalLLM
 
 
 RESULT_ROOT = config.get('storage.result_root', 'result')
@@ -50,7 +51,8 @@ def process_docs(args):
     setup_logging(os.path.join(work_dir, 'ano-rag.log'))
     logger.info(f"Using work dir: {work_dir}")
 
-    processor = DocumentProcessor(output_dir=work_dir)
+    llm = LocalLLM()
+    processor = DocumentProcessor(output_dir=work_dir, llm=llm)
 
     extensions = [".json", ".jsonl", ".docx"]
     src_dir = cfg.get('storage', {}).get('source_docs_dir', 'data')
@@ -100,11 +102,13 @@ def query_mode(args):
         except Exception as e:
             logger.warning(f'Failed to load embeddings: {e}')
 
+    llm = LocalLLM()
     processor = QueryProcessor(
         notes,
         embeddings,
         graph_file=graph_file if os.path.exists(graph_file) else None,
         vector_index_file=vector_index_file if vector_index_file and os.path.exists(vector_index_file) else None,
+        llm=llm,
     )
     output = processor.process(args.query)
     print(output['answer'])

--- a/query/query_processor.py
+++ b/query/query_processor.py
@@ -3,7 +3,7 @@ from loguru import logger
 import os
 import numpy as np
 
-from llm import QueryRewriter, OllamaClient
+from llm import QueryRewriter, OllamaClient, LocalLLM
 from vector_store import VectorRetriever, EnhancedRecallOptimizer
 from graph.graph_builder import GraphBuilder
 from graph.graph_index import GraphIndex
@@ -31,8 +31,9 @@ class QueryProcessor:
         embeddings=None,
         graph_file: Optional[str] = None,
         vector_index_file: Optional[str] = None,
+        llm: Optional[LocalLLM] = None,
     ):
-        self.rewriter = QueryRewriter()
+        self.rewriter = QueryRewriter(llm=llm)
         self.vector_retriever = VectorRetriever()
         if vector_index_file and os.path.exists(vector_index_file):
             try:


### PR DESCRIPTION
## Summary
- Allow `DocumentProcessor` and `QueryProcessor` to accept an external `LocalLLM`
- Instantiate a single `LocalLLM` in entry points like `MusiqueProcessor` and `main.py` and pass it to downstream processors
- Support evaluator and enhanced relation extractor for new configuration

## Testing
- `pytest tests/test_fast_semantic_relations.py -q`
- `pytest tests -q`
- `pytest -q` *(fails: fixture 'thread_id' not found in test_embedding_fix.py)*

------
https://chatgpt.com/codex/tasks/task_e_689f7c79c490832da57661a1539a275c