### PR TITLE
Fix LM Studio health check helper naming conflict

### DIFF
--- a/llm/lmstudio_client.py
+++ b/llm/lmstudio_client.py
@@ -452,7 +452,7 @@ class LMStudioClient:
             instance.last_health_check = current_time
             return is_healthy
         
-        return any(instance.is_healthy and self._quick_health_check(instance) for instance in self.instances)
+        return self._refresh_instances_health()
     
     def list_models(self) -> List[str]:
         """List available models from LM Studio."""
@@ -533,8 +533,8 @@ class LMStudioClient:
             ]
         }
     
-    def _quick_health_check(self, instance=None):
-        """Quick health check for LM Studio instances with retry and backoff."""
+    def _refresh_instances_health(self, instance: Optional[LMStudioInstance] = None) -> bool:
+        """Refresh health information for LM Studio instances with retry and backoff."""
         if instance is None:
             # Check all instances
             all_models = set()
@@ -547,12 +547,12 @@ class LMStudioClient:
                         all_models.update(models)
                     except Exception as e:
                         logger.debug(f"Failed to list models for {inst.base_url}: {e}")
-            
+
             self.all_models = all_models
             return len([inst for inst in self.instances if inst.is_healthy]) > 0
-        else:
-            # Check specific instance
-            return self._quick_health_check_single_instance(instance)
+
+        # Check specific instance
+        return self._quick_health_check_single_instance(instance)
     
     def _quick_health_check_single_instance(self, instance: LMStudioInstance) -> bool:
         """Quick health check for a single instance with retry mechanism."""


### PR DESCRIPTION
## Summary
- rename the multi-instance health refresh helper to `_refresh_instances_health` so it no longer overrides the single-instance `_quick_health_check`
- update `is_available` to continue using the single-instance check for specific instances and refresh multi-instance health via the renamed helper

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'enhanced_evaluator')*


------
https://chatgpt.com/codex/tasks/task_e_68ca95dca668832dab860ef473436de2