### PR TITLE
Introduce structured retrieval result object and propagate metadata

### DIFF
--- a/vector_store/__init__.py
+++ b/vector_store/__init__.py
@@ -1,6 +1,7 @@
 from .embedding_manager import EmbeddingManager
 from .vector_index import VectorIndex
 from .retriever import VectorRetriever
+from .retrieval_result import HybridRetrievalResult
 from .enhanced_recall_optimizer import EnhancedRecallOptimizer
 from .embedding_strategy import (
     EmbeddingStrategy,
@@ -17,7 +18,8 @@ from .embedding_strategy import (
 __all__ = [
     'EmbeddingManager', 
     'VectorIndex', 
-    'VectorRetriever', 
+    'VectorRetriever',
+    'HybridRetrievalResult',
     'EnhancedRecallOptimizer',
     'EmbeddingStrategy',
     'EmbeddingConfig',

--- a/vector_store/retrieval_result.py
+++ b/vector_store/retrieval_result.py
@@ -1,0 +1,138 @@
+"""Utilities for representing structured retrieval results."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict, Iterable, Iterator, Mapping, MutableMapping, Optional, Sequence
+
+
+def resolve_candidate_id(candidate: Mapping[str, Any]) -> Optional[str]:
+    """Derive a stable identifier for a retrieved candidate."""
+
+    for key in ("note_id", "id", "uuid", "document_id", "doc_id"):
+        value = candidate.get(key)
+        if value is not None:
+            return str(value)
+
+    content = candidate.get("content") or candidate.get("text")
+    if isinstance(content, str) and content:
+        digest = hashlib.sha1(content.encode("utf-8")).hexdigest()
+        return f"content:{digest}"
+
+    retrieval = candidate.get("retrieval_info")
+    if isinstance(retrieval, Mapping):
+        rid = retrieval.get("candidate_id")
+        if rid is not None:
+            return str(rid)
+
+    return None
+
+
+def merge_per_candidate_maps(
+    base: MutableMapping[str, Any], incoming: Mapping[str, Any]
+) -> MutableMapping[str, Any]:
+    """Merge two per-candidate metadata mappings."""
+
+    for key, value in incoming.items():
+        if key in base and isinstance(base[key], Mapping) and isinstance(value, Mapping):
+            merged = dict(base[key])
+            merged.update(value)
+            base[key] = merged
+        elif isinstance(value, Mapping):
+            base[key] = dict(value)
+        else:
+            base[key] = value
+    return base
+
+
+def normalize_timestamp(value: Any) -> Optional[float]:
+    """Normalize various timestamp representations to epoch seconds."""
+
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str) and value:
+        text = value.strip()
+        if not text:
+            return None
+        if text.isdigit():
+            try:
+                return float(text)
+            except ValueError:
+                return None
+        try:
+            return datetime.fromisoformat(text.replace("Z", "+00:00")).timestamp()
+        except ValueError:
+            for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%d"):
+                try:
+                    return datetime.strptime(text, fmt).timestamp()
+                except ValueError:
+                    continue
+    return None
+
+
+def collect_topical_tags(note: Mapping[str, Any]) -> Sequence[str]:
+    """Collect topical hints from candidate level metadata."""
+
+    tags: list[str] = []
+
+    def _extend(value: Any) -> None:
+        if value is None:
+            return
+        if isinstance(value, str):
+            parts = [part.strip() for part in value.split(",")]
+            tags.extend(part for part in parts if part)
+        elif isinstance(value, Iterable):
+            for item in value:
+                if isinstance(item, str) and item:
+                    tags.append(item)
+
+    for key in ("topical_tags", "keywords", "concepts", "topics", "tags"):
+        _extend(note.get(key))
+
+    metadata = note.get("metadata")
+    if isinstance(metadata, Mapping):
+        for key in ("keywords", "concepts", "topics", "tags"):
+            _extend(metadata.get(key))
+
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for tag in tags:
+        normalized = tag.strip()
+        if not normalized:
+            continue
+        if normalized.lower() in seen:
+            continue
+        seen.add(normalized.lower())
+        deduped.append(normalized)
+
+    return deduped
+
+
+@dataclass
+class HybridRetrievalResult(Sequence[Dict[str, Any]]):
+    """Container that couples candidates with per-candidate metadata."""
+
+    candidates: list[Dict[str, Any]] = field(default_factory=list)
+    per_candidate: dict[str, Dict[str, Any]] = field(default_factory=dict)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __iter__(self) -> Iterator[Dict[str, Any]]:
+        return iter(self.candidates)
+
+    def __len__(self) -> int:
+        return len(self.candidates)
+
+    def __getitem__(self, item: int) -> Dict[str, Any]:
+        return self.candidates[item]
+
+    def extend(self, other: "HybridRetrievalResult") -> None:
+        self.candidates.extend(other.candidates)
+        merge_per_candidate_maps(self.per_candidate, other.per_candidate)
+
+    def to_list(self) -> list[Dict[str, Any]]:
+        return list(self.candidates)
+


### PR DESCRIPTION
## Summary
- add `HybridRetrievalResult` to capture candidates plus canonical per-candidate metadata
- update the vector retriever to emit structured results, normalize timestamps and paragraph identifiers, and reuse topical tags
- adapt the query processor pipeline and recall optimizer to merge structured metadata through fallback, hybrid fusion, and graph expansion while deduplicating via canonical IDs
- export the new result type for downstream consumers

## Testing
- `pytest` *(fails: missing optional module `enhanced_evaluator` during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68d1085e045c832dad2534ba8eeb2ed6