### PR TITLE
Add configurable note completeness validation

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -310,6 +310,29 @@ notes_llm:
     max_tokens: 128            # 限制输出长度，提高响应速度
     stop: ["\n\n", "~"]        # 停止标记，遇到双换行或哨兵字符时停止
 
+note_completeness:
+  require_sentence_terminal: true
+  allowed_sentence_terminals: ["。", ".", "!", "?"]
+
+  # 长度下限（避免标题/短片段）
+  min_word_count_en: 5
+  min_char_count_zh: 10
+
+  # 句子必须包含谓词（英文/中文动词线索）
+  verb_patterns_en:
+    - "\\b(is|are|was|were|has|have|had|includes?|included|include|acquired|founded|located|born|won|announced|reported|published|proposed|launched)\\b"
+  verb_patterns_zh:
+    - "(是|为|位于|属于|出生|成立|获得|提出|报道|宣布|包含|推出|发布)"
+
+  # 禁止以从属/介词等开头（英文/中文）
+  bad_starts_en:
+    - "^(in|on|at|by|because|due to|such as|including|with|without|after|before|when|where|which|that|therefore|thus)\\b"
+  bad_starts_zh:
+    - "^(因此|因为|由于|其中|包括|以及|和|但|并|而|则|在|于|对|从|当|若|如果|虽然|然而)"
+
+  # entities 字段要求
+  require_entities: true
+
 # 增强关系提取配置
 enhanced_relation_extraction:
   use_llm_extraction: true     # 是否启用LLM增强的语义关系提取

--- a/utils/note_completeness.py
+++ b/utils/note_completeness.py
@@ -1,0 +1,97 @@
+"""Utilities for validating note completeness based on configuration rules."""
+
+from functools import lru_cache
+import re
+from typing import Dict, List, Any
+
+from config import config
+
+
+@lru_cache(maxsize=1)
+def _compiled_rules() -> Dict[str, Any]:
+    """Load and compile completeness rules from configuration."""
+
+    cfg = config.get("note_completeness", {}) or {}
+
+    def get_list(key: str) -> List[str]:
+        values = cfg.get(key, [])
+        if isinstance(values, list):
+            return [str(x) for x in values]
+        if values is None:
+            return []
+        return [str(values)]
+
+    def get_bool(key: str, default: bool = False) -> bool:
+        value = cfg.get(key, default)
+        return bool(value)
+
+    def get_int(key: str, default: int = 0) -> int:
+        value = cfg.get(key, default)
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return default
+
+    rules = {
+        "require_sentence_terminal": get_bool("require_sentence_terminal", True),
+        "allowed_sentence_terminals": get_list("allowed_sentence_terminals") or ["。", ".", "!", "?"],
+        "min_word_count_en": get_int("min_word_count_en", 5),
+        "min_char_count_zh": get_int("min_char_count_zh", 10),
+        "verb_patterns_en": [re.compile(pattern, re.I) for pattern in get_list("verb_patterns_en")],
+        "verb_patterns_zh": [re.compile(pattern) for pattern in get_list("verb_patterns_zh")],
+        "bad_starts_en": [re.compile(pattern, re.I) for pattern in get_list("bad_starts_en")],
+        "bad_starts_zh": [re.compile(pattern) for pattern in get_list("bad_starts_zh")],
+        "require_entities": get_bool("require_entities", True),
+    }
+
+    return rules
+
+
+def _word_count_en(text: str) -> int:
+    """Approximate English word count in the text."""
+
+    return len(re.findall(r"\w+", text))
+
+
+def _char_count_zh(text: str) -> int:
+    """Approximate count of Chinese characters in the text."""
+
+    return len(re.findall(r"[\u4e00-\u9fff]", text))
+
+
+def is_complete_sentence(text: str, entities: List[str]) -> bool:
+    """Determine whether a note text qualifies as a complete proposition."""
+
+    if not text:
+        return False
+
+    trimmed = text.strip()
+    if not trimmed:
+        return False
+
+    rules = _compiled_rules()
+
+    if rules["require_sentence_terminal"] and not any(
+        trimmed.endswith(char) for char in rules["allowed_sentence_terminals"]
+    ):
+        return False
+
+    if _word_count_en(trimmed) < rules["min_word_count_en"] and _char_count_zh(trimmed) < rules["min_char_count_zh"]:
+        return False
+
+    has_verb = any(pattern.search(trimmed) for pattern in rules["verb_patterns_en"]) or any(
+        pattern.search(trimmed) for pattern in rules["verb_patterns_zh"]
+    )
+    if not has_verb:
+        return False
+
+    if any(pattern.search(trimmed) for pattern in rules["bad_starts_en"]) or any(
+        pattern.search(trimmed) for pattern in rules["bad_starts_zh"]
+    ):
+        return False
+
+    if rules["require_entities"]:
+        if not isinstance(entities, list) or len(entities) == 0:
+            return False
+
+    return True

--- a/utils/notes_parser.py
+++ b/utils/notes_parser.py
@@ -8,6 +8,8 @@ import re
 from typing import List, Dict, Any, Optional, Union
 from loguru import logger
 
+from utils.note_completeness import is_complete_sentence
+
 
 def parse_notes_response(raw: str, sentinel: str = "~") -> Optional[List[Dict[str, Any]]]:
     """
@@ -120,7 +122,13 @@ def validate_note_structure(note: Dict[str, Any]) -> bool:
         if not isinstance(salience, (int, float)) or not (0 <= salience <= 1):
             logger.debug(f"Invalid salience: {salience}")
             return False
-        
+
+        text = str(note.get('text', '')).strip()
+        entities = note.get('entities', [])
+        if not is_complete_sentence(text, entities):
+            logger.debug(f"Reject incomplete/fragment note: {text}")
+            return False
+
         return True
         
     except (KeyError, TypeError, ValueError) as e:


### PR DESCRIPTION
## Summary
- add note_completeness configuration to centralize sentence rules
- introduce utils.note_completeness module and enforce completeness in parsing and quality filtering
- render multi-note prompts and enhanced generator post-processing from configuration values

## Testing
- python -m compileall utils/note_completeness.py utils/notes_parser.py utils/notes_quality_filter.py llm/prompts.py llm/enhanced_atomic_note_generator.py

------
https://chatgpt.com/codex/tasks/task_e_68e360ea07bc832dbea4742c49f04cad