### PR TITLE
Add coverage safeguards and recovery to atomic note generation

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -310,6 +310,10 @@ notes_llm:
     max_tokens: 128            # 限制输出长度，提高响应速度
     stop: ["\n\n", "~"]        # 停止标记，遇到双换行或哨兵字符时停止
 
+notes_prompt:
+  element_conservation: true        # 启用显式要素守恒提示（主体/时间/地点等不可拆散）
+  enumeration_split: true           # 对枚举项重复主体拆分完整句
+
 note_completeness:
   require_sentence_terminal: true
   allowed_sentence_terminals: ["。", ".", "!", "?"]
@@ -332,6 +336,19 @@ note_completeness:
 
   # entities 字段要求
   require_entities: true
+
+note_recovery:
+  enable: true
+  jaccard_threshold: 0.6
+  merge_threshold: 0.35
+  max_merge_tokens: 30
+  max_new_notes: 3
+
+evaluation:
+  coverage_thresholds:
+    warning: 0.7
+    critical: 0.5
+  coverage_report_path: "debug/coverage_report.json"
 
 # 增强关系提取配置
 enhanced_relation_extraction:

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -106,6 +106,11 @@ DEFAULT_CONFIG: Dict[str, Any] = {
     "hybrid_search": {
         "enabled": True,
         "fusion_method": "linear",
+        "prf_bridge": {
+            "enabled": True,
+            "first_hop_topk": 2,
+            "prf_topk": 20,
+        },
         "linear": {
             "vector_weight": 1.0,
             "bm25_weight": 0.5,


### PR DESCRIPTION
## Summary
- add prompt and recovery controls for atomic note generation in the shared configuration
- extend the multi-note prompt to enforce element conservation and enumeration splitting requirements
- integrate sentence-level coverage recovery, logging, and report export into the enhanced atomic note generator with supporting defaults

## Testing
- pytest tests/test_config_propagation.py

------
https://chatgpt.com/codex/tasks/task_e_68e36f12f880832dadcf2fcd97abaf45