### PR TITLE
Add relation-aware note enrichment and graph-based answer selection

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -19,6 +19,44 @@ embedding:
   max_length: 512            # 最大token长度，超出部分会被截断
   normalize: true            # 是否对向量进行归一化，提高相似度计算准确性
 
+# 原子笔记字段归一化与词表
+note_keys:
+  rel_lexicon:
+    performed_by: ["performed by", "the performer is", "由", "演奏"]
+    spouse_of: ["spouse", "partner", "married to", "配偶", "伴侣"]
+    born_in: ["born in", "出生于", "出生在"]
+    released_in: ["released in", "发行于", "发行在"]
+    member_of: ["member of", "成员", "属于"]
+  type_hints:
+    album: ["(album)"]
+    song: ["(song)"]
+    film: ["(film)"]
+    person: ["(person)", "先生", "女士", "Dr."]
+  normalize:
+    strip_quotes: true
+    collapse_space: true
+    lower: false
+
+# 原子笔记图构建权重
+graph:
+  edge:
+    key_match_weight: 1.5
+    type_compat_weight: 1.0
+    same_paragraph_bonus: 0.3
+
+# Beam Search 多跳检索参数
+multi_hop:
+  max_hops: 4
+  beam_size: 8
+  branch_factor: 6
+
+# 关系链答案选择器
+answer_selector:
+  enabled: true
+  anchor_top_k: 5
+  use_candidate_pool: true
+  apply_before_llm: true
+
 # 向量存储配置
 vector_store:
   top_k: 20                 # 检索候选数量，影响召回率和计算开销

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -13,6 +13,40 @@ DEFAULT_CONFIG: Dict[str, Any] = {
         "max_length": 512,
         "normalize": True,
     },
+    "note_keys": {
+        "rel_lexicon": {
+            "performed_by": ["performed by", "the performer is", "由", "演奏"],
+            "spouse_of": ["spouse", "partner", "married to", "配偶", "伴侣"],
+            "born_in": ["born in", "出生于", "出生在"],
+            "released_in": ["released in", "发行于", "发行在"],
+            "member_of": ["member of", "成员", "属于"],
+        },
+        "type_hints": {
+            "album": ["(album)"],
+            "song": ["(song)"],
+            "film": ["(film)"],
+            "person": ["(person)", "先生", "女士", "Dr."],
+        },
+        "normalize": {"strip_quotes": True, "collapse_space": True, "lower": False},
+    },
+    "graph": {
+        "edge": {
+            "key_match_weight": 1.5,
+            "type_compat_weight": 1.0,
+            "same_paragraph_bonus": 0.3,
+        }
+    },
+    "multi_hop": {
+        "max_hops": 4,
+        "beam_size": 8,
+        "branch_factor": 6,
+    },
+    "answer_selector": {
+        "enabled": True,
+        "anchor_top_k": 5,
+        "use_candidate_pool": True,
+        "apply_before_llm": True,
+    },
     # 添加存储配置默认值
     "storage": {
         "work_dir": "./result/work",

--- a/graph/__init__.py
+++ b/graph/__init__.py
@@ -4,6 +4,17 @@ from .graph_retriever import GraphRetriever
 from .relation_extractor import RelationExtractor
 from .graph_quality import compute_metrics
 from .graphml_exporter import GraphMLExporter
+from .index import NoteGraph
+from .search import Path, beam_search
 
-__all__ = ['GraphBuilder', 'GraphIndex', 'GraphRetriever', 'RelationExtractor',
-           'compute_metrics', 'GraphMLExporter']
+__all__ = [
+    'GraphBuilder',
+    'GraphIndex',
+    'GraphRetriever',
+    'RelationExtractor',
+    'compute_metrics',
+    'GraphMLExporter',
+    'NoteGraph',
+    'Path',
+    'beam_search',
+]

--- a/graph/index.py
+++ b/graph/index.py
@@ -1,0 +1,46 @@
+from collections import defaultdict
+from typing import Any, Dict, List, Tuple
+
+from config import config
+
+
+class NoteGraph:
+    """A lightweight graph where atomic notes become nodes connected via literals."""
+
+    def __init__(self) -> None:
+        self.notes: Dict[str, Dict[str, Any]] = {}
+        self.adj: Dict[str, List[Tuple[str, str, str, float, int]]] = defaultdict(list)
+
+        edge_cfg = config.get("graph.edge", {}) or {}
+        self.w_key = float(edge_cfg.get("key_match_weight", 1.5))
+        self.w_type = float(edge_cfg.get("type_compat_weight", 1.0))
+        self.b_para = float(edge_cfg.get("same_paragraph_bonus", 0.3))
+
+    def add_note(self, note: Dict[str, Any]) -> None:
+        text = str(note.get("text") or "").strip()
+        if not text:
+            return
+
+        note_id = note.get("id") or note.get("note_id") or str(hash(text))
+        note["id"] = note_id
+        self.notes[note_id] = note
+
+        head_key = note.get("head_key") or ""
+        tail_key = note.get("tail_key") or ""
+        if not head_key or not tail_key:
+            return
+
+        rel = note.get("rel") or "related_to"
+        paragraph_idxs = note.get("paragraph_idxs") or []
+        paragraph_idx = paragraph_idxs[0] if paragraph_idxs else -1
+
+        weight = self.w_key
+        if note.get("type_head") or note.get("type_tail"):
+            weight += self.w_type
+        if paragraph_idx >= 0:
+            weight += self.b_para
+
+        self.adj[head_key].append((rel, tail_key, note_id, weight, paragraph_idx))
+
+    def neighbors(self, head_key: str) -> List[Tuple[str, str, str, float, int]]:
+        return list(self.adj.get(head_key, []))

--- a/graph/search.py
+++ b/graph/search.py
@@ -1,0 +1,79 @@
+from dataclasses import dataclass, field
+from typing import Dict, List, Tuple
+
+from config import config
+
+
+@dataclass
+class Path:
+    keys: List[str] = field(default_factory=list)
+    notes: List[str] = field(default_factory=list)
+    rels: List[str] = field(default_factory=list)
+    score: float = 0.0
+
+    def last_key(self) -> str:
+        return self.keys[-1] if self.keys else ""
+
+    def extend(self, nb_key: str, rel: str, note_id: str, delta: float) -> "Path":
+        return Path(
+            keys=self.keys + [nb_key],
+            notes=self.notes + [note_id],
+            rels=self.rels + [rel],
+            score=self.score + float(delta),
+        )
+
+
+def beam_search(graph, anchors: List[str], rel_chain: List[str]) -> List[Path]:
+    max_hops = int(config.get("multi_hop.max_hops", 4))
+    beam_size = int(config.get("multi_hop.beam_size", 8))
+    branch = int(config.get("multi_hop.branch_factor", 6))
+
+    valid_anchors = [a for a in anchors if a]
+    if not valid_anchors:
+        return []
+
+    beams = [Path(keys=[anchor], notes=[], rels=[], score=0.0) for anchor in valid_anchors]
+    results: List[Path] = []
+
+    for hop in range(max_hops):
+        next_candidates: List[Path] = []
+        for path in beams:
+            current_key = path.last_key()
+            if not current_key:
+                continue
+            neighbors = graph.neighbors(current_key)
+            for rel, nb_key, note_id, weight, _para in neighbors:
+                if rel_chain and hop < len(rel_chain):
+                    constraint = rel_chain[hop]
+                    if constraint not in ("*", rel):
+                        continue
+                if nb_key in path.keys:
+                    continue
+                next_candidates.append(path.extend(nb_key, rel, note_id, weight))
+
+        if not next_candidates:
+            break
+
+        next_candidates.sort(key=lambda p: p.score, reverse=True)
+
+        pruned: List[Path] = []
+        bucket: Dict[Tuple[str, str], int] = {}
+        for candidate in next_candidates:
+            prev_key = candidate.keys[-2] if len(candidate.keys) >= 2 else ""
+            last_rel = candidate.rels[-1] if candidate.rels else ""
+            bucket_key = (prev_key, last_rel)
+            bucket.setdefault(bucket_key, 0)
+            if bucket[bucket_key] >= max(1, branch):
+                continue
+            bucket[bucket_key] += 1
+            pruned.append(candidate)
+            if len(pruned) >= beam_size:
+                break
+
+        beams = pruned
+        results.extend(pruned)
+        if not beams:
+            break
+
+    results.sort(key=lambda p: p.score, reverse=True)
+    return results[:beam_size]

--- a/llm/atomic_note_generator.py
+++ b/llm/atomic_note_generator.py
@@ -8,7 +8,12 @@ from .local_llm import LocalLLM
 from utils.batch_processor import BatchProcessor
 from utils.text_utils import TextUtils
 from utils.json_utils import extract_json_from_response, clean_control_characters
-from utils.notes_parser import parse_notes_response, filter_valid_notes, normalize_note_fields
+from utils.notes_parser import (
+    enrich_note_keys,
+    filter_valid_notes,
+    normalize_note_fields,
+    parse_notes_response,
+)
 from utils.notes_quality_filter import NotesQualityFilter
 from utils.notes_retry_handler import NotesRetryHandler
 from utils.notes_stats_logger import get_global_stats_logger, log_notes_stats, finalize_notes_session
@@ -381,10 +386,11 @@ class AtomicNoteGenerator:
 
         # 标准化笔记字段
         normalized_notes = [normalize_note_fields(note) for note in parsed_notes]
+        enriched_notes = [enrich_note_keys(note) for note in normalized_notes]
 
         # 对每条笔记执行后处理
         post_processed_notes = []
-        for note in normalized_notes:
+        for note in enriched_notes:
             processed_note = self._post_process_llm_note(note, chunk_data)
             if processed_note:
                 post_processed_notes.append(processed_note)

--- a/llm/local_llm.py
+++ b/llm/local_llm.py
@@ -12,6 +12,7 @@ from .multi_model_client import MultiModelClient
 from .factory import LLMFactory
 from .prompts import (
     ATOMIC_NOTE_SYSTEM_PROMPT,
+    ATOMIC_NOTE_SYSTEM_PROMPT_V2,
     ATOMIC_NOTE_PROMPT,
     EXTRACT_ENTITIES_SYSTEM_PROMPT,
     EXTRACT_ENTITIES_PROMPT,
@@ -352,7 +353,9 @@ class LocalLLM:
     
     def generate_atomic_notes(self, text_chunks: List[str]) -> List[Dict[str, Any]]:
         """生成原子笔记"""
-        system_prompt = ATOMIC_NOTE_SYSTEM_PROMPT
+        notes_cfg = config.get('notes_llm', {}) or {}
+        use_v2 = bool(notes_cfg.get('use_v2_schema', True))
+        system_prompt = ATOMIC_NOTE_SYSTEM_PROMPT_V2 if use_v2 else ATOMIC_NOTE_SYSTEM_PROMPT
         
         def process_chunk(chunk):
             prompt = ATOMIC_NOTE_PROMPT.format(chunk=chunk)

--- a/llm/parallel_task_atomic_note_generator.py
+++ b/llm/parallel_task_atomic_note_generator.py
@@ -8,7 +8,7 @@ from .local_llm import LocalLLM
 from .ollama_client import OllamaClient
 from .lmstudio_client import LMStudioClient
 from utils.json_utils import extract_json_from_response
-from utils.notes_parser import parse_notes_response
+from utils.notes_parser import enrich_note_keys, normalize_note_fields, parse_notes_response
 from config import config
 from .prompts import (
     ATOMIC_NOTEGEN_SYSTEM_PROMPT,
@@ -98,7 +98,9 @@ class ParallelTaskAtomicNoteGenerator(AtomicNoteGenerator):
 
     def _batch_convert(self, note_data, chunk_data):
         notes_raw = self._normalize_to_notes(note_data)
-        return [self._convert_to_atomic_note_format(n, chunk_data) for n in notes_raw]
+        normalized = [normalize_note_fields(n) for n in notes_raw]
+        enriched = [enrich_note_keys(n) for n in normalized]
+        return [self._convert_to_atomic_note_format(n, chunk_data) for n in enriched]
     
     def generate_atomic_notes(self, text_chunks: List[Dict[str, Any]], progress_tracker: Optional[Any] = None) -> List[Dict[str, Any]]:
         """生成原子笔记的主入口，支持并行任务分配"""

--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -1,6 +1,7 @@
 """Pipeline utilities for evidence post-processing."""
 
+from .answer_selector import answer_question
 from .evidence_rerank import EvidenceReranker
 from .path_validator import PathValidator
 
-__all__ = ["EvidenceReranker", "PathValidator"]
+__all__ = ["EvidenceReranker", "PathValidator", "answer_question"]

--- a/pipeline/answer_selector.py
+++ b/pipeline/answer_selector.py
@@ -1,0 +1,68 @@
+from typing import Any, Dict, List
+
+from graph.index import NoteGraph
+from graph.search import Path, beam_search
+
+
+def extract_rel_chain(question: str) -> List[str]:
+    """Placeholder for relation-chain extraction logic."""
+
+    _ = question
+    return []
+
+
+def select_answer_from_paths(paths: List[Path], target_rel: str) -> Dict[str, Any]:
+    if not paths:
+        return {}
+
+    for path in paths:
+        if not path.rels:
+            continue
+        if target_rel and path.rels[-1] != target_rel:
+            continue
+        return {
+            "answer": path.keys[-1],
+            "support_note_ids": path.notes,
+            "rels": path.rels,
+            "path_score": path.score,
+            "path_keys": path.keys,
+        }
+
+    best = paths[0]
+    return {
+        "answer": best.keys[-1],
+        "support_note_ids": best.notes,
+        "rels": best.rels,
+        "path_score": best.score,
+        "path_keys": best.keys,
+    }
+
+
+def answer_question(question: str, notes: List[Dict[str, Any]], anchors: List[str]) -> Dict[str, Any]:
+    graph = NoteGraph()
+    for note in notes:
+        graph.add_note(note)
+
+    anchor_list = anchors or []
+    if not anchor_list:
+        anchor_list = [note.get("head_key") for note in notes if note.get("head_key")]
+    anchor_list = [a for a in anchor_list if a]
+    # Deduplicate anchors while preserving order
+    seen = set()
+    deduped_anchors = []
+    for anchor in anchor_list:
+        if anchor in seen:
+            continue
+        seen.add(anchor)
+        deduped_anchors.append(anchor)
+
+    if not deduped_anchors:
+        return {}
+
+    rel_chain = extract_rel_chain(question)
+    paths = beam_search(graph, deduped_anchors, rel_chain)
+    if not paths:
+        return {}
+
+    target_rel = rel_chain[-1] if rel_chain else ""
+    return select_answer_from_paths(paths, target_rel)


### PR DESCRIPTION
## Summary
- extend atomic note prompting with a configurable schema that emits relation, head/tail keys, and type hints
- add deterministic key enrichment plus lightweight note graph and beam-search utilities for multi-hop reasoning
- integrate a rule-based answer selector before final generation, wiring new configuration knobs for lexicons and search weights

## Testing
- python -m compileall llm utils graph pipeline query

------
https://chatgpt.com/codex/tasks/task_e_68e4ee549550832db4b3aea56c16033b