### PR TITLE
feat: adopt note graph schema v2

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -57,6 +57,18 @@ answer_selector:
   use_candidate_pool: true
   apply_before_llm: true
 
+evidence_rerank:
+  enable: true
+  w_album: 0.5
+  w_song: -0.3
+  w_supporting: 0.4
+  w_q_performer_album: 0.3
+  album_tokens: ["(album)", " album"]
+  song_tokens: ["(song)", " single", "(film)"]
+  support_flag_keys: ["is_supporting", "supporting"]
+  query_performer_terms: ["performer", "singer", "vocalist"]
+  query_album_terms: ["album", "record", "ep"]
+
 # 向量存储配置
 vector_store:
   top_k: 20                 # 检索候选数量，影响召回率和计算开销
@@ -329,6 +341,7 @@ atomic_note_generation:
 
 # 原子笔记生成优化配置
 notes_llm:
+  use_v2_schema: true
   max_note_chars: 200
   # 流式处理早停机制配置
   stream_early_stop: true      # 启用流式处理早停机制
@@ -387,7 +400,7 @@ note_completeness:
   require_entities: false
 
 quality_filter:
-  require_entities: true
+  require_entities: false
   min_chars: 20
 
 note_recovery:

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -302,6 +302,7 @@ DEFAULT_CONFIG: Dict[str, Any] = {
         "max_chars": 400,
         "min_salience": 0.3,
         "max_notes_per_chunk": 12,
+        "max_note_chars": 200,
         "enable_rule_fallback": True,
         "entities_fallback": {
             "enabled": True,
@@ -323,7 +324,7 @@ DEFAULT_CONFIG: Dict[str, Any] = {
         }
     },
     "quality_filter": {
-        "require_entities": True,
+        "require_entities": False,
         "min_chars": 20,
         "min_salience": 0.3,
     },
@@ -337,6 +338,18 @@ DEFAULT_CONFIG: Dict[str, Any] = {
         "bad_starts_en": [],
         "bad_starts_zh": [],
         "require_entities": False,
+    },
+    "evidence_rerank": {
+        "enable": True,
+        "w_album": 0.5,
+        "w_song": -0.3,
+        "w_supporting": 0.4,
+        "w_q_performer_album": 0.3,
+        "album_tokens": ["(album)", " album"],
+        "song_tokens": ["(song)", " single", "(film)"],
+        "support_flag_keys": ["is_supporting", "supporting"],
+        "query_performer_terms": ["performer", "singer", "vocalist"],
+        "query_album_terms": ["album", "record", "ep"],
     },
     "vector_store": {
         "top_k": 20,

--- a/graph/index.py
+++ b/graph/index.py
@@ -12,11 +12,9 @@ class NoteGraph:
         self.adj: Dict[str, List[Tuple[str, str, str, float, int]]] = defaultdict(list)
 
         edge_cfg = config.get("graph.edge", {}) or {}
-        self.base_weight = float(edge_cfg.get("base_weight", 0.0))
         self.w_key = float(edge_cfg.get("key_match_weight", 1.5))
         self.w_type = float(edge_cfg.get("type_compat_weight", 1.0))
         self.b_para = float(edge_cfg.get("same_paragraph_bonus", 0.3))
-        self.b_title = float(edge_cfg.get("same_title_bonus", 0.0))
         self.default_rel = str(config.get("note_keys.default_rel", "related_to"))
 
     def add_note(self, note: Dict[str, Any]) -> None:
@@ -37,20 +35,14 @@ class NoteGraph:
         paragraph_idxs = note.get("paragraph_idxs") or []
         paragraph_idx = paragraph_idxs[0] if paragraph_idxs else -1
 
-        weight = self.base_weight
-        if head_key and tail_key:
-            weight += self.w_key
+        weight = self.w_key
 
         type_head = note.get("type_head")
         type_tail = note.get("type_tail")
-        if type_head and type_tail:
+        if type_head or type_tail:
             weight += self.w_type
         if paragraph_idx >= 0:
             weight += self.b_para
-
-        title = (note.get("title") or "").strip()
-        if title:
-            weight += self.b_title
 
         self.adj[head_key].append((rel, tail_key, note_id, weight, paragraph_idx))
 

--- a/graph/search.py
+++ b/graph/search.py
@@ -50,7 +50,7 @@ def beam_search(
     beams = [Path(keys=[anchor], notes=[], rels=[], score=0.0) for anchor in valid_anchors]
     completed: List[Path] = []
 
-    for hop in range(max_hops):
+    for _hop in range(max_hops):
         next_candidates: List[Path] = []
         for path in beams:
             current_key = path.last_key()
@@ -97,5 +97,10 @@ def beam_search(
             break
 
     results = completed if completed else beams
+    # Drop degenerate paths that never traversed an edge (no supporting notes).
+    results = [path for path in results if path.notes]
+    if not results:
+        return []
+
     results.sort(key=lambda p: p.score, reverse=True)
     return results[:beam_size]


### PR DESCRIPTION
## Summary
- add a configurable V2 atomic note prompt contract and expose the toggle in the default configuration
- harden note parsing and filtering by enriching relation slots before quality checks and relaxing the entity requirement
- update the note-graph search/answer selection stack and surface lightweight evidence reranker defaults in configuration files
- prevent empty multi-hop graph paths from surfacing without supporting notes to avoid downstream idx errors

## Testing
- `pytest tests/test_config_propagation.py`


------
https://chatgpt.com/codex/tasks/task_e_68e50f68d004832dab3f8490c4ad0c57